### PR TITLE
Добавлены MD-отчёты по файлам qiki_docgen

### DIFF
--- a/docs/advanced_component_proto_template.md
+++ b/docs/advanced_component_proto_template.md
@@ -1,0 +1,89 @@
+СПИСОК ФАЙЛОВ  
+1. QIKI_DTMP/tools/qiki_docgen/core/generator.py  
+2. QIKI_DTMP/tools/qiki_docgen/core/parser.py  
+3. QIKI_DTMP/tools/qiki_docgen/requirements.txt  
+4. QIKI_DTMP/tools/qiki_docgen/templates/advanced_component.proto.template  
+5. QIKI_DTMP/tools/qiki_docgen/templates/advanced_design.md.template  
+
+---
+
+### Вход и цель  
+[Факт] Шаблон расширенного Proto контракта.  
+Цель — описать структуру и риски.
+
+### Сбор контекста  
+[Факт] Использует Jinja2‑переменные `component_name`, `component_proto_type`.  
+[Гипотеза] Для крупного enterprise‑компонента.
+
+### Локализация артефакта  
+`tools/qiki_docgen/templates/advanced_component.proto.template`; компилируется `protoc`.
+
+### Фактический разбор  
+- Message `{{ component_proto_type }}`, `Configuration`, `ResourceLimits`, `HealthStatus`, `Metrics`.  
+- Services с CRUD, batch, search, streaming.  
+- Большой набор enums и вспомогательных типов.
+
+### Роль в системе и связи  
+[Факт] Служит базовым шаблоном для новых компонент.  
+[Гипотеза] Применяется при `create_proto_contract`.
+
+### Несоответствия и риски  
+- [Факт] Не указан пакет `common_types.proto` источник — **Med**.  
+- [Факт] Нет опции customize по feature flags — **Low**.  
+- [Гипотеза] Шаблон может быть избыточным для маленьких сервисов — **Low**.
+
+### Мини-патчи  
+- [Патч] Указать `syntax = "proto3";` в начале (есть).  
+- [Патч] Добавить комментарии по optional/required.
+
+### Рефактор-скетч  
+```proto
+message {{ component_proto_type }} {
+  qiki.common.UUID id = 1;
+  string name = 2;
+  // ...
+  optional Configuration config = 13;
+}
+```
+
+### Примеры использования  
+```bash
+# 1. Генерация файла
+python -m qiki_docgen.generator create_proto_contract Foo --template advanced
+# 2. Компиляция
+protoc -I=. --python_out=. foo.proto
+# 3. Проверка enum
+grep "EntityStatus" foo.proto
+# 4. Смена имени
+python -m qiki_docgen.generator create_proto_contract Bar --dry-run
+# 5. Использование в gRPC
+python -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. foo.proto
+```
+
+### Тест‑хуки/чек‑лист  
+- Прогон `protoc` на сгенерированном файле.  
+- Проверка импорта `common_types.proto`.  
+- Генерация Python и TypeScript кодов.  
+- Тест на отсутствующие поля в CRUD запросах.  
+- Соответствие имен service и messages.
+
+### Вывод  
+1. Шаблон богат функционалом.  
+2. Требует внешних зависимостей (`common_types.proto`).  
+3. Избыточен для простых сервисов.  
+4. Нужна документация по настройкам.  
+5. Возможны конфликты имен.  
+6. Стоит параметризовать включаемые секции.  
+7. Проверить совместимость с gRPC‑Gateway.  
+8. Добавить опцию отключения health/metrics.  
+9. Прописать версии пакета.  
+10. Рефактор: разнести на части, подключать по флагам.
+
+---
+
+СПИСОК ФАЙЛОВ  
+1. QIKI_DTMP/tools/qiki_docgen/core/generator.py  
+2. QIKI_DTMP/tools/qiki_docgen/core/parser.py  
+3. QIKI_DTMP/tools/qiki_docgen/requirements.txt  
+4. QIKI_DTMP/tools/qiki_docgen/templates/advanced_component.proto.template  
+5. QIKI_DTMP/tools/qiki_docgen/templates/advanced_design.md.template  

--- a/docs/advanced_design_md_template.md
+++ b/docs/advanced_design_md_template.md
@@ -1,0 +1,88 @@
+СПИСОК ФАЙЛОВ  
+1. QIKI_DTMP/tools/qiki_docgen/core/generator.py  
+2. QIKI_DTMP/tools/qiki_docgen/core/parser.py  
+3. QIKI_DTMP/tools/qiki_docgen/requirements.txt  
+4. QIKI_DTMP/tools/qiki_docgen/templates/advanced_component.proto.template  
+5. QIKI_DTMP/tools/qiki_docgen/templates/advanced_design.md.template  
+
+---
+
+### Вход и цель  
+[Факт] Jinja2‑шаблон для расширенного дизайн‑документа.  
+Цель — оценить структуру и полноту разделов.
+
+### Сбор контекста  
+[Факт] YAML frontmatter, множество секций (Executive Summary, API, Deployment…).  
+[Гипотеза] Используется как скелет для архитектурных документов.
+
+### Локализация артефакта  
+`tools/qiki_docgen/templates/advanced_design.md.template`; применяется `create_design_document`.
+
+### Фактический разбор  
+- Frontmatter: `component_name`, `version`, `author`, `status`, `tags`.  
+- 15 разделов, включающие бизнес‑контекст, тестирование, риски, changelog.  
+- Кодовые примеры: Mermaid диаграмма, SQL, YAML.
+
+### Роль в системе и связи  
+[Факт] Входной шаблон для проектной документации.  
+[Гипотеза] Служит стандартом для команды разработки.
+
+### Несоответствия и риски  
+- [Факт] Жестко прошитые даты (`2025‑08‑05`) — **Med**.  
+- [Факт] Нет ссылок на реальный ADR/API путь — **Low**.  
+- [Гипотеза] Документ может быть слишком громоздким для MVP — **Low**.
+
+### Мини-патчи  
+- [Патч] Использовать `created_at|default(now())`.  
+- [Патч] Добавить placeholder для ревью даты.
+
+### Рефактор-скетч  
+```markdown
+---
+component_name: {{ component_name }}
+created_at: {{ created_at | default(now()) }}
+review_due: {{ review_due | default("") }}
+---
+```
+
+### Примеры использования  
+```bash
+# 1. Генерация документа
+python -m qiki_docgen.generator create_design_document Foo docs/foo.md --template advanced
+# 2. Dry-run
+python -m qiki_docgen.generator create_design_document Foo docs/foo.md --dry-run
+# 3. Заполнение переменных
+jinja2-cli advanced_design.md.template component_name=Bar author="Team"
+# 4. Проверка frontmatter
+head -n 10 docs/foo.md
+# 5. Превращение в PDF
+pandoc docs/foo.md -o docs/foo.pdf
+```
+
+### Тест‑хуки/чек‑лист  
+- Корректность YAML frontmatter.  
+- Наличие всех 15 разделов после генерации.  
+- Unicode в `component_name`.  
+- Валидация списков и таблиц.  
+- Проверка ссылки на связанные документы.
+
+### Вывод  
+1. Шаблон очень полный, покрывает жизненный цикл.  
+2. Дата и автор по умолчанию требуют динамики.  
+3. Можно упрощать для легких проектов.  
+4. Добавить переменные для review/owner.  
+5. Предусмотреть перевод на другие языки.  
+6. Хранить пример в тестах для регрессии.  
+7. Разделить на модули (API, Deployment) по необходимости.  
+8. Встроить ссылки на ADR/API.  
+9. Автоматизировать заполнение changelog.  
+10. Сначала патч‑фиксы (даты), позже — модульность.
+
+---
+
+СПИСОК ФАЙЛОВ  
+1. QIKI_DTMP/tools/qiki_docgen/core/generator.py  
+2. QIKI_DTMP/tools/qiki_docgen/core/parser.py  
+3. QIKI_DTMP/tools/qiki_docgen/requirements.txt  
+4. QIKI_DTMP/tools/qiki_docgen/templates/advanced_component.proto.template  
+5. QIKI_DTMP/tools/qiki_docgen/templates/advanced_design.md.template  

--- a/docs/generator.md
+++ b/docs/generator.md
@@ -1,0 +1,87 @@
+СПИСОК ФАЙЛОВ  
+1. QIKI_DTMP/tools/qiki_docgen/core/generator.py  
+2. QIKI_DTMP/tools/qiki_docgen/core/parser.py  
+3. QIKI_DTMP/tools/qiki_docgen/requirements.txt  
+4. QIKI_DTMP/tools/qiki_docgen/templates/advanced_component.proto.template  
+5. QIKI_DTMP/tools/qiki_docgen/templates/advanced_design.md.template  
+
+---
+
+### Вход и цель  
+[Факт] Анализируем модуль генерации документации и Proto‑контрактов.  
+Цель — обзор возможностей и потенциальных улучшений.
+
+### Сбор контекста  
+[Факт] Используются `Jinja2`, `subprocess`, `shutil`, парсеры из `parser.py` и конфигурация `config.py`.  
+[Гипотеза] Модуль задуман как CLI‑утилита в составе doc‑генератора.
+
+### Локализация артефакта  
+`tools/qiki_docgen/core/generator.py`; Python 3.11+, запускается как библиотека/скрипт.
+
+### Фактический разбор  
+- `to_snake_case`, `create_design_document`, `create_proto_contract`, `compile_protos`, `build_readme`.  
+- Сбор путей из конфигурации, работа с Jinja‑шаблонами, запуск `protoc`.
+
+### Роль в системе и связи  
+[Факт] Центральная точка генерации артефактов; зависит от `parser.py` и конфигурации.  
+[Гипотеза] Встраивается в CI/CD для автоматизации документации.
+
+### Несоответствия и риски  
+- [Факт] Нет проверки существования шаблонов — **Med**.  
+- [Факт] `compile_protos` удаляет `generated_dir` без бэкапа — **Med**.  
+- [Гипотеза] Ошибки не пробрасываются вверх в `create_*` — **Low**.
+
+### Мини-патчи  
+- [Патч] Проверять `template` перед рендерингом.  
+- [Патч] В `compile_protos` использовать `exist_ok=True` при создании каталога.
+
+### Рефактор-скетч  
+```python
+def safe_render(template_name, **ctx):
+    env = _get_jinja_env()
+    if template_name not in env.list_templates():
+        raise FileNotFoundError(template_name)
+    return env.get_template(template_name).render(**ctx)
+```
+
+### Примеры использования  
+```bash
+# 1. Создание design.md
+python -m qiki_docgen.generator create_design_document Foo docs/Foo_design.md
+# 2. Создание proto
+python -m qiki_docgen.generator create_proto_contract Foo
+# 3. Dry‑run README
+python -m qiki_docgen.generator build_readme --dry-run
+# 4. Компиляция proto
+python -m qiki_docgen.generator compile_protos
+# 5. Смена шаблона
+python -m qiki_docgen.generator create_design_document Bar docs/Bar.md --template advanced
+```
+
+### Тест‑хуки/чек‑лист  
+- Unit: `to_snake_case` (разные кейсы).  
+- Интеграция: `create_proto_contract` + проверка файла.  
+- Негативные: отсутствие `protoc`.  
+- Проверка dry‑run режимов.  
+- README собирается без шаблонов.
+
+### Вывод  
+1. Модуль зрелый, но требует валидаций.  
+2. Добавить проверки существования шаблонов.  
+3. Защитить удаление `generated_dir`.  
+4. Расширить логирование ошибок.  
+5. Вынести общие утилиты в отдельный модуль.  
+6. Настроить покрытие тестами.  
+7. Документировать CLI параметры.  
+8. Рассмотреть async для I/O операций.  
+9. Подумать о конфигурируемом логгере.  
+10. План: патч‑фиксы сейчас, рефактор позже.
+
+---
+
+СПИСОК ФАЙЛОВ  
+1. QIKI_DTMP/tools/qiki_docgen/core/generator.py  
+2. QIKI_DTMP/tools/qiki_docgen/core/parser.py  
+3. QIKI_DTMP/tools/qiki_docgen/requirements.txt  
+4. QIKI_DTMP/tools/qiki_docgen/templates/advanced_component.proto.template  
+5. QIKI_DTMP/tools/qiki_docgen/templates/advanced_design.md.template  

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -1,0 +1,87 @@
+СПИСОК ФАЙЛОВ  
+1. QIKI_DTMP/tools/qiki_docgen/core/generator.py  
+2. QIKI_DTMP/tools/qiki_docgen/core/parser.py  
+3. QIKI_DTMP/tools/qiki_docgen/requirements.txt  
+4. QIKI_DTMP/tools/qiki_docgen/templates/advanced_component.proto.template  
+5. QIKI_DTMP/tools/qiki_docgen/templates/advanced_design.md.template  
+
+---
+
+### Вход и цель  
+[Факт] Модуль парсинга `.proto` и `design.md`.  
+Цель — разобраться в извлечении структуры.
+
+### Сбор контекста  
+[Факт] Использует `Path`, `re`, стандартные коллекции.  
+[Гипотеза] Предназначен для построения README и метаданных.
+
+### Локализация артефакта  
+`tools/qiki_docgen/core/parser.py`; импортируется в генератор.
+
+### Фактический разбор  
+- Класс `ProtoParser`: извлекает package, messages, enums, services.  
+- Класс `DesignDocParser`: обрабатывает frontmatter, секции, metadata.
+
+### Роль в системе и связи  
+[Факт] Поставщик структурированных данных для генератора.  
+[Гипотеза] Может использоваться автономно для анализа репо.
+
+### Несоответствия и риски  
+- [Факт] Регулярные выражения без защиты от вложенных блоков — **Med**.  
+- [Факт] Невалидация YAML frontmatter — **Low**.  
+- [Гипотеза] Ограничение на 5 строк комментария — **Low**.
+
+### Мини-патчи  
+- [Патч] Ограничить `re.finditer` по времени или глубине.  
+- [Патч] Добавить try/except для `_extract_sections`.
+
+### Рефактор-скетч  
+```python
+@dataclass
+class ProtoMessage:
+    name: str
+    fields: list[Field]
+    description: str = ""
+```
+
+### Примеры использования  
+```python
+# 1. Парсинг proto
+ProtoParser().parse_proto_file(Path("sample.proto"))
+# 2. Парсинг design.md
+DesignDocParser().parse_design_doc(Path("docs/foo.md"))
+# 3. Получение только messages
+parser = ProtoParser(); parser.parse_proto_file(p)["messages"]
+# 4. Проверка наличия frontmatter
+DesignDocParser().parse_design_doc(p)["has_frontmatter"]
+# 5. Вручную извлечь секции
+DesignDocParser()._extract_sections(text)
+```
+
+### Тест‑хуки/чек‑лист  
+- Proto с вложенными message/enum.  
+- Design без frontmatter.  
+- Ошибочный YAML.  
+- Наличие комментариев перед блоками.  
+- Unicode в именах.
+
+### Вывод  
+1. Парсер покрывает основные сущности.  
+2. Регулярки могут ломаться на сложных файлах.  
+3. Желательно использовать protobuf‑компилятор для AST.  
+4. Для design.md — рассмотреть PyYAML.  
+5. Сократить дублирование кода.  
+6. Добавить типы (TypedDict/dataclass).  
+7. Улучшить логирование уровней.  
+8. Написать интеграционные тесты.  
+9. Проверить поддержку Windows путей.  
+10. Рефактор после стабилизации требований.
+
+---
+
+СПИСОК ФАЙЛОВ  
+1. QIKI_DTMP/tools/qiki_docgen/core/generator.py  
+2. QIKI_DTMP/tools/qiki_docgen/core/parser.py  
+3. QIKI_DTMP/tools/qiki_docgen/requirements.txt  
+4. QIKI_DTMP/tools/qiki_docgen/templates/advanced_component.proto.template  
+5. QIKI_DTMP/tools/qiki_docgen/templates/advanced_design.md.template  

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,84 @@
+СПИСОК ФАЙЛОВ  
+1. QIKI_DTMP/tools/qiki_docgen/core/generator.py  
+2. QIKI_DTMP/tools/qiki_docgen/core/parser.py  
+3. QIKI_DTMP/tools/qiki_docgen/requirements.txt  
+4. QIKI_DTMP/tools/qiki_docgen/templates/advanced_component.proto.template  
+5. QIKI_DTMP/tools/qiki_docgen/templates/advanced_design.md.template  
+
+---
+
+### Вход и цель  
+[Факт] Файл зависимостей для doc‑генератора.  
+Цель — проверить корректность и версии.
+
+### Сбор контекста  
+[Факт] Содержит `Jinja2` и `grpcio-tools>=1.62.0`.  
+[Гипотеза] Предназначен для локальной установки инструментов.
+
+### Локализация артефакта  
+`tools/qiki_docgen/requirements.txt`; используется `pip`.
+
+### Фактический разбор  
+- Две зависимости, без комментариев.  
+- Отсутствует завершающий перевод строки.
+
+### Роль в системе и связи  
+[Факт] Определяет окружение для генератора.  
+[Гипотеза] Может дополняться тестовыми пакетами.
+
+### Несоответствия и риски  
+- [Факт] Нет фиксации версий `Jinja2` — **Med**.  
+- [Факт] Отсутствует `protobuf` пакет — **Med**.
+
+### Мини-патчи  
+- [Патч] Добавить `Jinja2>=3.1,<4`.  
+- [Патч] В конце файла поставить newline.
+
+### Рефактор-скетч  
+```text
+Jinja2>=3.1,<4
+grpcio-tools>=1.62.0
+protobuf>=4.25
+```
+
+### Примеры использования  
+```bash
+# 1. Установка зависимостей
+pip install -r requirements.txt
+# 2. Обновление Jinja2
+pip install 'Jinja2>=3.1,<4' --upgrade
+# 3. Проверка версии grpcio-tools
+python -c "import grpc_tools; print(grpc_tools.__version__)"
+# 4. Заморозка зависимостей
+pip freeze > requirements.lock
+# 5. Использование виртуального окружения
+python -m venv venv && source venv/bin/activate
+```
+
+### Тест‑хуки/чек‑лист  
+- Проверить установку на чистой среде.  
+- Совместимость с Python 3.11.  
+- Конфликт версий при добавлении `protobuf`.  
+- Наличие lock‑файла в CI.  
+- Работа `protoc` после установки.
+
+### Вывод  
+1. Файл минималистичен, не фиксирует версии.  
+2. Следует указать диапазоны для предсказуемости.  
+3. Добавить отсутствующие зависимости (`protobuf`).  
+4. Рекомендуется lock‑файл.  
+5. Указать комментарии для контекста.  
+6. Учесть платформенные пакеты.  
+7. Проверить совместимость с M1.  
+8. Автоматизировать проверку `pip check`.  
+9. Периодически обновлять версии.  
+10. План: добавить версии и расширить список.
+
+---
+
+СПИСОК ФАЙЛОВ  
+1. QIKI_DTMP/tools/qiki_docgen/core/generator.py  
+2. QIKI_DTMP/tools/qiki_docgen/core/parser.py  
+3. QIKI_DTMP/tools/qiki_docgen/requirements.txt  
+4. QIKI_DTMP/tools/qiki_docgen/templates/advanced_component.proto.template  
+5. QIKI_DTMP/tools/qiki_docgen/templates/advanced_design.md.template  


### PR DESCRIPTION
## Summary
- create markdown analyses for generator, parser, requirements and advanced templates
- document risks, mini-patches and usage examples per file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a264235428833187304feed82834d4

## Summary by Sourcery

Add comprehensive markdown analysis documents for qiki_docgen modules and templates

Documentation:
- Add detailed markdown report for generator.py module
- Add detailed markdown report for parser.py module
- Add markdown analysis for requirements.txt
- Add documentation template report for advanced_component.proto.template
- Add documentation template report for advanced_design.md.template