### PR TITLE
Добавлены MD-анализы модулей q_core_agent

### DIFF
--- a/qiki_mission_control_analysis.md
+++ b/qiki_mission_control_analysis.md
@@ -1,0 +1,98 @@
+СПИСОК ФАЙЛОВ
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/qiki_mission_control_ultimate.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/qiki_mission_control.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/rule_engine.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/ship_actuators.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/ship_bios_handler.py
+
+# `/home/sonra44/QIKI_DTMP/services/q_core_agent/core/qiki_mission_control.py`
+
+## Вход и цель
+- [Факт] Модуль `QIKIMissionControl` — рабочий терминал без внешних зависимостей.
+- [Гипотеза] Итог — обзор и рекомендации по безопасному использованию.
+
+## Сбор контекста
+- [Факт] Использует ручной ASCII-интерфейс через `termios` и `select`.
+- [Гипотеза] В соседних файлах — `ship_actuators.py`, `test_ship_fsm.py`.
+- [Факт] Содержит поток `_background_processes` для телеметрии.
+
+## Локализация артефакта
+- [Факт] Путь: `services/q_core_agent/core/qiki_mission_control.py`.
+- [Гипотеза] Запуск: `python qiki_mission_control.py` в обычном терминале.
+- [Факт] Требует Python 3.10+.
+
+## Фактический разбор
+- [Факт] Импорты: `ShipCore`, `ShipActuatorController`, `ShipLogicController`.
+- [Факт] Методы: `log`, `_background_processes`, `_update_live_parameters`, `display_status`, `execute_command`, `run_interactive`.
+- [Факт] Хранит `navigation_data`, `sensor_data`, `mission_data`.
+- [Гипотеза] Команды пользователя парсятся строково без проверки типов.
+
+## Роль в системе и связи
+- [Факт] Консольное управление кораблём; используется в тестах и демонстрации.
+- [Гипотеза] Служит базовым CLI-интерфейсом для других модулей.
+
+## Несоответствия и риски
+- [Гипотеза] Отсутствие проверки пользовательских команд — Priority: High.
+- [Факт] Поток обновления параметров не останавливается корректно — Priority: Med.
+- [Гипотеза] Возможен переполнение `log_messages` при долгой сессии — Priority: Low.
+
+## Мини-патчи (safe-fix)
+- [Патч] Добавить в `execute_command` проверку допустимых команд.
+- [Патч] В `run_interactive` закрывать поток через `join()`.
+- [Патч] Ограничить `log_messages` по размеру.
+
+## Рефактор-скетч
+```python
+def main():
+    with MissionControl() as mc:
+        while mc.running:
+            cmd = input("> ")
+            mc.execute_command(cmd)
+```
+
+## Примеры использования
+```python
+# 1. Старт терминала
+from qiki_mission_control import QIKIMissionControl
+mc = QIKIMissionControl()
+mc.display_status()
+
+# 2. Выполнение команды
+mc.execute_command("thrust 25")
+
+# 3. Получение телеметрии
+telemetry = mc._get_telemetry()
+print(telemetry["reactor_output"])
+
+# 4. Запуск интерактивного режима
+mc.run_interactive()
+
+# 5. Завершение работы
+mc.running = False
+```
+
+## Тест-хуки/чек-лист
+- Проверка обработки неизвестных команд.
+- Лимит `log_messages` ≤100.
+- Фоновый поток завершается после `running=False`.
+- Команда `thrust` вызывает `ShipActuatorController.set_main_drive_thrust`.
+- Интерфейс корректно выводит строки без артефактов в `termios`.
+
+## Вывод
+1. [Факт] Модуль предоставляет CLI-управление без зависимостей.
+2. [Гипотеза] Параметры миссии могут устаревать без синхронизации.
+3. [Факт] Логирование ограничено только в памяти.
+4. [Гипотеза] Командный синтаксис не стандартизирован.
+5. [Патч] Ввести словарь разрешённых команд.
+6. [Факт] Поток обновляет телеметрию каждые 3 сек.
+7. [Гипотеза] Не хватает тестов для состояния `autopilot`.
+8. [Патч] Разделить ввод/вывод и ядро логики.
+9. [Гипотеза] Возможно внедрить очереди событий.
+10. [Факт] Базовый CLI работает, но требует проверки ввода.
+
+СПИСОК ФАЙЛОВ
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/qiki_mission_control_ultimate.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/qiki_mission_control.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/rule_engine.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/ship_actuators.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/ship_bios_handler.py

--- a/qiki_mission_control_ultimate_analysis.md
+++ b/qiki_mission_control_ultimate_analysis.md
@@ -1,0 +1,105 @@
+СПИСОК ФАЙЛОВ
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/qiki_mission_control_ultimate.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/qiki_mission_control.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/rule_engine.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/ship_actuators.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/ship_bios_handler.py
+
+# `/home/sonra44/QIKI_DTMP/services/q_core_agent/core/qiki_mission_control_ultimate.py`
+
+## Вход и цель
+- [Факт] Модуль с интерфейсом `QIKIMissionControlUltimate` — полноценный терминал на `prompt_toolkit`.
+- [Гипотеза] Итог — обзор поведения, поиск рисков, патч-скетч и примеры.
+
+## Сбор контекста
+- [Факт] Исходник использует `prompt_toolkit`; при отсутствии пытается установить библиотеку через `pip`.
+- [Факт] Рядом в репо лежат `ship_core.py`, `ship_actuators.py`, `test_ship_fsm.py`.
+- [Гипотеза] Тесты запускаются вручную, автоматической сборки нет.
+
+## Локализация артефакта
+- [Факт] Путь: `services/q_core_agent/core/qiki_mission_control_ultimate.py`.
+- [Факт] Окружение: Python 3.12+, Unix/Linux терминал, возможно Termux.
+- [Гипотеза] Запуск как `python qiki_mission_control_ultimate.py`.
+
+## Фактический разбор
+- [Факт] Импорты: `prompt_toolkit`, `ShipCore`, `ShipActuatorController`, `ShipLogicController`.
+- [Факт] Класс `QIKIMissionControlUltimate`: методы `log`, `_background_simulation`, `_update_live_telemetry`, UI-конструкторы (`_create_header_window`, `_create_layout`), `run_simple_mode`, `run`.
+- [Факт] Хранит `mission_data`, `live_telemetry`, журнал событий.
+- [Гипотеза] Поток `_background_simulation` симулирует параметры раз в несколько секунд.
+- [Факт] Автопилот реализован через `ShipLogicController`.
+
+## Роль в системе и связи
+- [Факт] Служит фронтендом для управления кораблём.
+- [Гипотеза] Вызывается оператором; отдаёт команды в `ShipActuatorController` и получает телеметрию из `ShipCore`.
+- [Гипотеза] Риски: длительный UI-цикл блокирует другие процессы.
+
+## Несоответствия и риски
+- [Факт] Auto-pip внутри кода (установка `prompt_toolkit`) — Priority: High.
+- [Гипотеза] Журнал событий ограничен 20 записями, возможна потеря важных данных — Priority: Med.
+- [Гипотеза] Нет обработки исключений при запуске фонового потока — Priority: Med.
+
+## Мини-патчи (safe-fix)
+- [Патч] Удалить автоматическую установку `pip`, заменить на сообщение об ошибке.
+- [Патч] Добавить параметр размера журнала и вынести в конфиг.
+- [Патч] Обернуть запуск фонового потока в try/except с логированием.
+
+## Рефактор-скетч (по желанию)
+```python
+# skeleton
+class MissionControlUI:
+    def __init__(self, core, actuators, logic, ui_factory):
+        self.core = core
+        self.actuators = actuators
+        self.logic = logic
+        self.ui = ui_factory()
+
+    def run(self):
+        while True:
+            self.ui.render(self.core.telemetry())
+```
+
+## Примеры использования
+```python
+# 1. Запуск в упрощённом режиме
+from qiki_mission_control_ultimate import QIKIMissionControlUltimate
+mc = QIKIMissionControlUltimate()
+mc.run_simple_mode()
+
+# 2. Логирование события
+mc.log("TEST", "Проверка")
+
+# 3. Переключение автопилота
+mc.autopilot_enabled = True
+
+# 4. Получение времени миссии
+print(mc._get_mission_time())
+
+# 5. Завершение работы
+mc.running = False
+```
+
+## Тест-хуки/чек-лист
+- Проверить запуск без `prompt_toolkit` → корректная ошибка.
+- Эмуляция обновления телеметрии: данные не выходят за границы.
+- Фоновые потоки завершаются при `running=False`.
+- В журнал добавляется не более N записей.
+- Автопилот меняет `ship_state` при логическом цикле.
+
+## Вывод
+1. [Факт] Код создаёт профессиональный терминал.
+2. [Гипотеза] Потоки могут привести к гонкам данных.
+3. [Факт] Автопилот интегрирован, но не изолирован от UI.
+4. [Гипотеза] Авто-pip затрудняет развёртывание.
+5. [Факт] Живые данные симулируются случайно.
+6. [Гипотеза] Нет логирования ошибок в UI.
+7. [Патч] Ввести конфиги для параметров симуляции.
+8. [Патч] Добавить тесты на перезапуск UI.
+9. [Гипотеза] Возможно разделить модель и представление.
+10. [Факт] Основные функции работают, но требуют отделения зависимостей.
+
+СПИСОК ФАЙЛОВ
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/qiki_mission_control_ultimate.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/qiki_mission_control.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/rule_engine.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/ship_actuators.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/ship_bios_handler.py

--- a/rule_engine_analysis.md
+++ b/rule_engine_analysis.md
@@ -1,0 +1,94 @@
+СПИСОК ФАЙЛОВ
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/qiki_mission_control_ultimate.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/qiki_mission_control.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/rule_engine.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/ship_actuators.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/ship_bios_handler.py
+
+# `/home/sonra44/QIKI_DTMP/services/q_core_agent/core/rule_engine.py`
+
+## Вход и цель
+- [Факт] Класс `RuleEngine` реализует `IRuleEngine`; генерирует предложения действий.
+- [Гипотеза] Итог — чек-риск и патч-скетч.
+
+## Сбор контекста
+- [Факт] Использует Protobuf-сообщения (`Proposal`, `ActuatorCommand`, `FSMStateEnum`).
+- [Гипотеза] В окружении есть `generated/*.pb2` файлы.
+- [Факт] Зависит от `AgentContext` для проверки BIOS.
+
+## Локализация артефакта
+- [Факт] Путь: `services/q_core_agent/core/rule_engine.py`.
+- [Гипотеза] Вызывается агентом при каждом цикле принятия решения.
+
+## Фактический разбор
+- [Факт] Методы: `__init__`, `generate_proposals`.
+- [Факт] Правило: при `context.is_bios_ok()==False` предлагает `SAFE_MODE`.
+- [Гипотеза] Дополнительные правила пока не реализованы.
+
+## Роль в системе и связи
+- [Факт] Производит список `Proposal` для верхнего уровня агента.
+- [Гипотеза] Считывает состояние из `AgentContext` и передает команды в `ShipCore`.
+
+## Несоответствия и риски
+- [Гипотеза] Нет разграничения уровней приоритетов (значения захардкожены) — Priority: Med.
+- [Факт] Отсутствуют проверки на дублирование предложений — Priority: Low.
+- [Гипотеза] При отсутствии Protobuf зависимостей модуль не имеет fallback — Priority: Low.
+
+## Мини-патчи
+- [Патч] Вынести коэффициенты `priority` и `confidence` в конфиг.
+- [Патч] Добавить проверку, есть ли уже активное предложение `SAFE_MODE`.
+
+## Рефактор-скетч
+```python
+class Rule:
+    def evaluate(ctx) -> Optional[Proposal]: ...
+class RuleEngine:
+    def __init__(self, rules): self.rules = rules
+    def generate(self, ctx): return [r.evaluate(ctx) for r in self.rules if r.evaluate(ctx)]
+```
+
+## Примеры использования
+```python
+# 1. Инстанцирование
+engine = RuleEngine(context, {})
+
+# 2. Генерация предложений
+proposals = engine.generate_proposals(context)
+
+# 3. Проверка наличия safe-mode
+if any(p.type == Proposal.ProposalType.SAFETY for p in proposals):
+    print("SAFE MODE suggested")
+
+# 4. Добавление новой конфигурации
+engine.config["max_priority"] = 1.0
+
+# 5. Логгирование
+from core.agent_logger import logger
+logger.info(f"Generated {len(proposals)} proposals")
+```
+
+## Тест-хуки/чек-лист
+- Симулировать `BIOS not OK` → получаем `SAFE_MODE`.
+- Убедиться, что при `BIOS OK` список пуст.
+- Проверить корректность полей `Proposal` (ID, приоритет).
+- Обработка неизвестного `context` (исключения).
+- Подключение к реальному `AgentContext` без Protobuf ошибок.
+
+## Вывод
+1. [Факт] Реализовано минимальное правило безопасности.
+2. [Гипотеза] Конфигурация не используется.
+3. [Факт] Код лаконичен, но без расширяемости.
+4. [Гипотеза] Нужен механизм регистрации правил.
+5. [Патч] Ввести структуру `Rule` и списком.
+6. [Гипотеза] Логирование не учитывает контекст.
+7. [Факт] Возвращается список `Proposal`.
+8. [Патч] Добавить type-hints для `config`.
+9. [Гипотеза] Возможны гонки при многопоточном доступе.
+10. [Факт] Модуль годится для MVP, но требует расширения.
+
+СПИСОК ФАЙЛОВ
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/qiki_mission_control_ultimate.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/qiki_mission_control.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/rule_engine.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/ship_actuators.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/ship_bios_handler.py

--- a/ship_actuators_analysis.md
+++ b/ship_actuators_analysis.md
@@ -1,0 +1,95 @@
+СПИСОК ФАЙЛОВ
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/qiki_mission_control_ultimate.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/qiki_mission_control.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/rule_engine.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/ship_actuators.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/ship_bios_handler.py
+
+# `/home/sonra44/QIKI_DTMP/services/q_core_agent/core/ship_actuators.py`
+
+## Вход и цель
+- [Факт] Модуль управления исполнительными механизмами (`ShipActuatorController`).
+- [Гипотеза] Итог — обзор методов управления, безопасные патчи.
+
+## Сбор контекста
+- [Факт] Импортирует `ShipCore` и Protobuf `ActuatorCommand`.
+- [Факт] Определяет enum `ThrusterAxis`, `PropulsionMode`, dataclass `ThrustVector`, `PowerAllocation`.
+- [Гипотеза] Используется в миссион контроле и автопилоте.
+
+## Локализация артефакта
+- [Факт] Путь: `services/q_core_agent/core/ship_actuators.py`.
+- [Гипотеза] Требует наличия `ShipCore` с методом `send_actuator_command`.
+
+## Фактический разбор
+- [Факт] Методы: `set_main_drive_thrust`, `fire_rcs_thruster`, `execute_maneuver`, `emergency_stop`, `set_power_allocation`, `activate_sensor`, `deactivate_sensor`, `get_propulsion_status`, `get_control_summary`.
+- [Факт] Использует `ActuatorCommand` с полями `command_type`, `unit`, `ack_required`.
+- [Гипотеза] Исключения ведут к `False` без детальной информации.
+
+## Роль в системе и связи
+- [Факт] Интерфейс высокого уровня между миссион-контролем и низкоуровневыми актуаторами.
+- [Гипотеза] Неправильные параметры могут вызвать некорректное состояние пропульсии.
+
+## Несоответствия и риски
+- [Гипотеза] Отсутствует проверка связи с `ShipCore` перед отправкой — Priority: High.
+- [Факт] `emergency_stop` не гарантирует подтверждения — Priority: Med.
+- [Гипотеза] Некорректные значения `duration_sec` могут не валидироваться — Priority: Med.
+
+## Мини-патчи
+- [Патч] Проверять `self.ship_core` на `None` перед отправкой команд.
+- [Патч] В методах приводить `duration_sec` к целому таймауту ≥0.
+- [Патч] Логировать возвращаемые значения `False` с причиной.
+
+## Рефактор-скетч
+```python
+class ActuatorController:
+    def send(self, id, value, unit):
+        cmd = ActuatorCommand(actuator_id=UUID(value=id),
+                              float_value=value, unit=unit)
+        self.ship_core.send_actuator_command(cmd)
+```
+
+## Примеры использования
+```python
+# 1. Установка тяги основного двигателя
+controller.set_main_drive_thrust(75.0)
+
+# 2. Импульс RCS вперёд
+controller.fire_rcs_thruster(ThrusterAxis.FORWARD, 20.0, 0.5)
+
+# 3. Сложный манёвр
+vector = ThrustVector(x=5.0, y=0.0, z=-2.0)
+controller.execute_maneuver(vector, 3.0)
+
+# 4. Распределение питания
+alloc = PowerAllocation(life_support=10, propulsion=20, sensors=4)
+controller.set_power_allocation(alloc)
+
+# 5. Получение статуса
+print(controller.get_control_summary())
+```
+
+## Тест-хуки/чек-лист
+- Вызов `set_main_drive_thrust` с >100 → ограничение до 100.
+- Ошибка связи с `ship_core` → возвращает `False` и логирует.
+- `execute_maneuver` корректно формирует вектор команд.
+- `emergency_stop` отправляет команду `SET_VELOCITY` с 0 %.
+- `activate_sensor`/`deactivate_sensor` изменяют состояние без конфликта.
+
+## Вывод
+1. [Факт] Контроллер объединяет управление двигателями и сенсорами.
+2. [Гипотеза] Нет централизованной проверки входных данных.
+3. [Факт] Используются enums для читаемости.
+4. [Гипотеза] Возможны гонки при параллельных командах.
+5. [Патч] Добавить блокировки или очередь команд.
+6. [Факт] Методы возвращают bool без расшифровки ошибок.
+7. [Патч] Вернуть объект результата с кодом.
+8. [Гипотеза] Отсутствуют юнит-тесты на `PowerAllocation`.
+9. [Факт] Зависит от внешних Proto-классов.
+10. [Гипотеза] Для модульности можно изолировать отправку команд в отдельный слой.
+
+СПИСОК ФАЙЛОВ
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/qiki_mission_control_ultimate.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/qiki_mission_control.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/rule_engine.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/ship_actuators.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/ship_bios_handler.py

--- a/ship_bios_handler_analysis.md
+++ b/ship_bios_handler_analysis.md
@@ -1,0 +1,96 @@
+СПИСОК ФАЙЛОВ
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/qiki_mission_control_ultimate.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/qiki_mission_control.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/rule_engine.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/ship_actuators.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/ship_bios_handler.py
+
+# `/home/sonra44/QIKI_DTMP/services/q_core_agent/core/ship_bios_handler.py`
+
+## Вход и цель
+- [Факт] Класс `ShipBiosHandler` реализует диагностику BIOS корабля.
+- [Гипотеза] Итог — разбор алгоритма проверки систем и выявление рисков.
+
+## Сбор контекста
+- [Факт] Использует `ShipCore` и множество статусов (`HullStatus`, `PowerSystemStatus` и др.).
+- [Гипотеза] Предназначен для обработки `BiosStatusReport` из Protobuf.
+- [Факт] Имеет mock-классы для работы без зависимостей.
+
+## Локализация артефакта
+- [Факт] Путь: `services/q_core_agent/core/ship_bios_handler.py`.
+- [Гипотеза] Вызывается после POST-проверок корабля.
+
+## Фактический разбор
+- [Факт] Методы: `process_bios_status`, `_diagnose_hull`, `_diagnose_power_systems`, `_diagnose_propulsion`, `_diagnose_sensors`, `_diagnose_life_support`, `_diagnose_computing`, `get_system_health_summary`.
+- [Факт] Каждая диагностика возвращает статус и список проблем.
+- [Гипотеза] `health_score` вычисляется мультипликативно и может быстро падать.
+
+## Роль в системе и связи
+- [Факт] Проверяет состояние всех подсистем и формирует `BiosStatusReport`.
+- [Гипотеза] Результат передаётся в `RuleEngine` и Mission Control для принятия решений.
+
+## Несоответствия и риски
+- [Факт] Мультипликативное снижение `health_score` может давать 0 при множестве мелких проблем — Priority: Med.
+- [Гипотеза] Нет нормализации статусов между подсистемами — Priority: Med.
+- [Гипотеза] Mock-классы могут скрыть ошибки в интеграции — Priority: Low.
+
+## Мини-патчи
+- [Патч] Изменить расчёт `health_score` на средневзвешенный.
+- [Патч] Добавить типы возвращаемых списков (e.g., `List[Dict[str, str]]`).
+- [Патч] Отдельный метод для логирования первых N проблем.
+
+## Рефактор-скетч
+```python
+def _run_checks(self, checks):
+    issues = []
+    for name, func in checks:
+        status, errs = func()
+        issues.extend(errs)
+    return issues
+```
+
+## Примеры использования
+```python
+# 1. Создание обработчика
+handler = ShipBiosHandler(ship_core)
+
+# 2. Обработка отчёта BIOS
+report = handler.process_bios_status(BiosStatusReport())
+
+# 3. Получение сводки здоровья
+summary = handler.get_system_health_summary()
+print(summary["all_systems_go"])
+
+# 4. Диагностика только корпуса (внутренний вызов)
+status, issues = handler._diagnose_hull()
+
+# 5. Логирование обнаруженных проблем
+for issue in issues:
+    print(issue["device_id"], issue["message"])
+```
+
+## Тест-хуки/чек-лист
+- Все _diagnose_* возвращают кортеж (статус, список).
+- При низкой целостности корпуса возвращается `status='ERROR'`.
+- `process_bios_status` очищает старые `post_results`.
+- `health_score` не выходит за 0…1.
+- `get_system_health_summary` отражает поле `all_systems_go`.
+
+## Вывод
+1. [Факт] Модуль охватывает диагностику всех подсистем.
+2. [Гипотеза] Расчёт здоровья не масштабируется на большое число ошибок.
+3. [Факт] Используются mock-классы для автономности.
+4. [Гипотеза] Списки проблем не сортируются по критичности.
+5. [Патч] Ввод весов для каждой подсистемы.
+6. [Факт] Логируются первые пять проблем.
+7. [Гипотеза] Нужна локализация сообщений (`RU/EN`).
+8. [Патч] Добавить enum кодов ошибок для унификации.
+9. [Гипотеза] Возможен конфлик с другими обработчиками BIOS.
+10. [Факт] Код пригоден, но требует стандартизации метрик.
+
+СПИСОК ФАЙЛОВ
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/qiki_mission_control_ultimate.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/qiki_mission_control.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/rule_engine.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/ship_actuators.py
+- /home/sonra44/QIKI_DTMP/services/q_core_agent/core/ship_bios_handler.py


### PR DESCRIPTION
## Описание
- добавлены Markdown-документы с подробным анализом пяти ключевых файлов ядра агента

## Тестирование
- `pytest` (падает из-за отсутствующих зависимостей: google, psutil, yaml)


------
https://chatgpt.com/codex/tasks/task_e_68a2640a40188331a7fa11761f927eeb