### PR TITLE
Добавлены обзоры модулей q_core_agent/core

### DIFF
--- a/QIKI_DTMP/services/q_core_agent/core/__init__.analysis.md
+++ b/QIKI_DTMP/services/q_core_agent/core/__init__.analysis.md
@@ -1,0 +1,82 @@
+СПИСОК ФАЙЛОВ
+56. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/__init__.py
+57. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/agent_logger.py
+58. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/bios_handler.py
+59. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/bot_core.py
+60. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/mission_control_demo.py
+
+## Вход и цель
+- [Факт] Анализ файла `__init__.py` пакета `core`.
+- [Цель] Подготовить обзор и рекомендации.
+
+## Сбор контекста
+- [Факт] Файл пустой, не содержит кода.
+- [Гипотеза] Используется лишь для маркировки каталога как пакета.
+
+## Локализация артефакта
+- [Факт] Путь: `services/q_core_agent/core/__init__.py`.
+- [Гипотеза] Загружается при `import services.q_core_agent.core`.
+
+## Фактический разбор
+- [Факт] Классы/функции отсутствуют.
+- [Факт] Нет импорта и логики.
+- [Гипотеза] Отсутствие `__all__` может приводить к неявным экспортам.
+
+## Роль в системе и связи
+- [Факт] Определяет пакет для модулей `agent_logger`, `bios_handler` и др.
+- [Гипотеза] Может служить местом для общих настроек пакета.
+
+## Несоответствия и риски
+- [Гипотеза][Low] Пустой файл не документирует назначение пакета.
+
+## Мини-патчи (safe-fix)
+- [Патч] Добавить докстринг и список экспортируемых модулей.
+
+## Рефактор-скетч
+```python
+"""Инициализация пакета core."""
+__all__ = ["agent_logger", "bios_handler", "bot_core", "mission_control_demo"]
+```
+
+## Примеры использования
+```python
+# 1. Импорт пакета
+from services.q_core_agent import core
+
+# 2. Импорт подмодуля
+from services.q_core_agent.core import agent_logger
+
+# 3. Проверка наличия атрибута
+import importlib
+core_pkg = importlib.import_module('services.q_core_agent.core')
+print(hasattr(core_pkg, '__all__'))
+
+# 4. Повторный импорт
+importlib.reload(core_pkg)
+
+# 5. Список доступных модулей
+print([m for m in dir(core_pkg) if not m.startswith('_')])
+```
+
+## Тест-хуки/чек-лист
+- Импорт пакета не должен выбрасывать исключений.
+- Пакет предоставляет ожидаемые подмодули в `__all__`.
+
+## Вывод
+1. Файл выполняет лишь роль маркера пакета.
+2. Отсутствует документация и явный экспорт модулей.
+3. Риск низкий, но возможны недоразумения при импорте.
+4. Рекомендуется добавить докстринг и `__all__`.
+5. Проверка импорта проста и не требует зависимостей.
+6. Дальнейшие улучшения — описать предназначение пакета.
+7. Поддержка тестов минимальна.
+8. Использование пакета безопасно.
+9. Дополнительные функции можно добавлять позже.
+10. Полноценная архитектура не требуется.
+
+СПИСОК ФАЙЛОВ
+56. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/__init__.py
+57. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/agent_logger.py
+58. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/bios_handler.py
+59. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/bot_core.py
+60. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/mission_control_demo.py

--- a/QIKI_DTMP/services/q_core_agent/core/agent_logger.analysis.md
+++ b/QIKI_DTMP/services/q_core_agent/core/agent_logger.analysis.md
@@ -1,0 +1,100 @@
+СПИСОК ФАЙЛОВ
+56. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/__init__.py
+57. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/agent_logger.py
+58. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/bios_handler.py
+59. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/bot_core.py
+60. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/mission_control_demo.py
+
+## Вход и цель
+- [Факт] Анализ модуля `agent_logger.py` для настройки логирования.
+- [Цель] Сформировать обзор, риски и предложения.
+
+## Сбор контекста
+- [Факт] Использует `logging`, `yaml`, `os`.
+- [Факт] Читает конфигурацию из `logging.yaml` или пути из переменной `LOG_CFG`.
+- [Гипотеза] Предполагается наличие файла конфигурации рядом с модулем.
+
+## Локализация артефакта
+- [Факт] Путь: `services/q_core_agent/core/agent_logger.py`.
+- [Факт] Функция `setup_logging` вызывается при старте сервиса.
+
+## Фактический разбор
+- [Факт] `setup_logging` загружает YAML-конфиг и настраивает `logging`.
+- [Факт] При ошибке чтения конфигурации используется `basicConfig`.
+- [Гипотеза] Логгер `q_core_agent` служит корневым для всей службы.
+
+## Роль в системе и связи
+- [Факт] Предоставляет единый логгер для остальных модулей.
+- [Гипотеза] Некорректная конфигурация может скрыть важные сообщения.
+
+## Несоответствия и риски
+- [Факт][Med] Исключения при чтении YAML печатаются в stdout вместо логирования.
+- [Гипотеза][Low] Отсутствие проверки структуры конфигурации.
+
+## Мини-патчи (safe-fix)
+- [Патч] Логировать ошибки через `logging.error`.
+- [Патч] Добавить проверку наличия ключевых секций в конфиге.
+
+## Рефактор-скетч
+```python
+import logging, os, yaml
+
+def setup_logging(path='logging.yaml', level=logging.INFO):
+    try:
+        with open(os.getenv('LOG_CFG', path), 'rt') as f:
+            logging.config.dictConfig(yaml.safe_load(f))
+    except Exception as e:
+        logging.basicConfig(level=level)
+        logging.getLogger(__name__).error("Logging setup failed: %s", e)
+
+logger = logging.getLogger("q_core_agent")
+```
+
+## Примеры использования
+```python
+# 1. Базовая инициализация
+from services.q_core_agent.core import agent_logger
+agent_logger.setup_logging()
+agent_logger.logger.info("Старт")
+
+# 2. Пользовательский файл конфигурации
+agent_logger.setup_logging('/tmp/logging.yaml')
+
+# 3. Использование переменной окружения
+import os
+os.environ['LOG_CFG'] = '/tmp/logging.yaml'
+agent_logger.setup_logging()
+
+# 4. Установка уровня DEBUG
+agent_logger.setup_logging(default_level=agent_logger.logging.DEBUG)
+
+# 5. Логирование исключения
+try:
+    1/0
+except ZeroDivisionError:
+    agent_logger.logger.exception("Ошибка вычислений")
+```
+
+## Тест-хуки/чек-лист
+- Конфигурация загружается из файла и из `LOG_CFG`.
+- При отсутствии файла используется `basicConfig`.
+- Ошибки настройки выводятся в лог.
+
+## Вывод
+1. Модуль централизует логирование сервиса.
+2. Есть обработка ошибок, но она выводит на stdout.
+3. Риск среднего уровня: потеря логов при плохом конфиге.
+4. Рекомендуется логировать ошибки через `logger`.
+5. Стоит валидировать структуру YAML.
+6. При тестах проверять чтение конфигов и уровни логгера.
+7. Модуль простой и не требует сложной архитектуры.
+8. Расширение возможно для динамической смены уровня.
+9. Документация ограничена строками кода.
+10. Общая работоспособность зависит от внешних файлов.
+
+СПИСОК ФАЙЛОВ
+56. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/__init__.py
+57. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/agent_logger.py
+58. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/bios_handler.py
+59. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/bot_core.py
+60. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/mission_control_demo.py

--- a/QIKI_DTMP/services/q_core_agent/core/bios_handler.analysis.md
+++ b/QIKI_DTMP/services/q_core_agent/core/bios_handler.analysis.md
@@ -1,0 +1,109 @@
+СПИСОК ФАЙЛОВ
+56. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/__init__.py
+57. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/agent_logger.py
+58. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/bios_handler.py
+59. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/bot_core.py
+60. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/mission_control_demo.py
+
+## Вход и цель
+- [Факт] Рассматривается класс `BiosHandler`.
+- [Цель] Разобрать обработку статуса BIOS и дать рекомендации.
+
+## Сбор контекста
+- [Факт] Импортирует `IBiosHandler`, `logger`, `BotCore`, `BiosStatusReport`, `DeviceStatus`, `UUID`.
+- [Факт] Опирается на `hardware_profile` из `BotCore`.
+- [Гипотеза] Используется как часть диагностической цепочки.
+
+## Локализация артефакта
+- [Факт] Путь: `services/q_core_agent/core/bios_handler.py`.
+- [Гипотеза] Вызывается модулем диагностики при получении отчёта BIOS.
+
+## Фактический разбор
+- [Факт] `process_bios_status` копирует входной отчёт и проверяет устройства.
+- [Факт] Отсутствующие устройства помечаются `NOT_FOUND` и добавляются в список.
+- [Факт] Итоговый флаг `all_systems_go` зависит от статусов устройств.
+- [Гипотеза] Логика не проверяет дубликаты и валидность UUID.
+
+## Роль в системе и связи
+- [Факт] Сравнивает отчёт BIOS с конфигурацией оборудования.
+- [Гипотеза] Результат влияет на дальнейшее решение о запуске системы.
+
+## Несоответствия и риски
+- [Факт][Med] Нет проверки на дублирование `device_id`.
+- [Гипотеза][Low] Отсутствует валидация структуры `hardware_profile`.
+
+## Мини-патчи (safe-fix)
+- [Патч] Добавить проверку уникальности `device_id` в отчёте.
+- [Патч] Логировать количество необработанных устройств.
+
+## Рефактор-скетч
+```python
+class BiosHandler(IBiosHandler):
+    def __init__(self, bot_core: BotCore):
+        self.bot_core = bot_core
+
+    def process_bios_status(self, bios_status: BiosStatusReport) -> BiosStatusReport:
+        updated = BiosStatusReport()
+        updated.CopyFrom(bios_status)
+        profile = self.bot_core.get_property("hardware_profile") or {}
+        expected = {x["id"] for x in profile.get("actuators", [])+profile.get("sensors", [])}
+        seen = {ds.device_id.value for ds in bios_status.post_results}
+        for dev in expected - seen:
+            updated.post_results.append(DeviceStatus(
+                device_id=UUID(value=dev),
+                status=DeviceStatus.Status.NOT_FOUND,
+                status_code=DeviceStatus.StatusCode.COMPONENT_NOT_FOUND
+            ))
+        updated.all_systems_go = all(ds.status == DeviceStatus.Status.OK for ds in updated.post_results)
+        return updated
+```
+
+## Примеры использования
+```python
+# 1. Создание обработчика
+from services.q_core_agent.core.bot_core import BotCore
+from services.q_core_agent.core.bios_handler import BiosHandler
+bot = BotCore('/path/to/q_core_agent')
+handler = BiosHandler(bot)
+
+# 2. Пустой отчёт BIOS
+from generated.bios_status_pb2 import BiosStatusReport
+report = BiosStatusReport()
+handler.process_bios_status(report)
+
+# 3. Отчёт с устройством
+from generated.bios_status_pb2 import DeviceStatus
+report.post_results.append(DeviceStatus(device_id=UUID(value='motor_left')))
+handler.process_bios_status(report)
+
+# 4. Использование аппаратного профиля
+bot.get_property('hardware_profile')
+
+# 5. Логирование предупреждения
+from services.q_core_agent.core.agent_logger import logger
+logger.warning('Проверка BIOS завершена')
+```
+
+## Тест-хуки/чек-лист
+- Проверить добавление устройств из профиля, отсутствующих в отчёте.
+- Убедиться, что `all_systems_go` корректно вычисляется.
+- Проверить реакцию на дубли `device_id`.
+
+## Вывод
+1. Класс сопоставляет отчёт BIOS с конфигурацией.
+2. Обработка выполняется в один проход по устройствам.
+3. Средний риск: дубли и неверный профиль не обрабатываются.
+4. Рекомендуется добавить проверки уникальности и структуры.
+5. Логирование присутствует, но можно расширить метрики.
+6. Тесты должны покрывать случаи отсутствия устройств и ошибки статусов.
+7. Расширение возможно через интеграцию с отдельным сервисом BIOS.
+8. Код читаемый и следует PEP8.
+9. Для минимального режима логирование предупреждает о профильных данных.
+10. Архитектура проста и подходит для MVP.
+
+СПИСОК ФАЙЛОВ
+56. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/__init__.py
+57. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/agent_logger.py
+58. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/bios_handler.py
+59. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/bot_core.py
+60. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/mission_control_demo.py

--- a/QIKI_DTMP/services/q_core_agent/core/bot_core.analysis.md
+++ b/QIKI_DTMP/services/q_core_agent/core/bot_core.analysis.md
@@ -1,0 +1,100 @@
+СПИСОК ФАЙЛОВ
+56. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/__init__.py
+57. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/agent_logger.py
+58. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/bios_handler.py
+59. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/bot_core.py
+60. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/mission_control_demo.py
+
+## Вход и цель
+- [Факт] Анализ класса `BotCore`.
+- [Цель] Описать функциональность ядра бота и предложить улучшения.
+
+## Сбор контекста
+- [Факт] Использует JSON-конфиг `bot_config.json` и файл `.qiki_bot.id`.
+- [Факт] Применяет модули `sensor_raw_in_pb2`, `actuator_raw_out_pb2`.
+- [Гипотеза] Конфиг хранится в `base_path/config`.
+
+## Локализация артефакта
+- [Факт] Путь: `services/q_core_agent/core/bot_core.py`.
+- [Факт] Инициализируется в сервисах, требующих доступ к сенсорам и актуаторам.
+
+## Фактический разбор
+- [Факт] `_load_config` читает JSON, поддерживает режим `minimal`.
+- [Факт] `_initialize_bot_id` создаёт или читает идентификатор бота.
+- [Факт] `_process_incoming_sensor_data` обновляет снимок и вызывает колбэки.
+- [Факт] `send_actuator_command` валидирует `actuator_id` и сохраняет команду.
+- [Гипотеза] История сенсоров пока не реализована (`get_sensor_history`).
+
+## Роль в системе и связи
+- [Факт] Центральная точка доступа к конфигурации и I/O бота.
+- [Гипотеза] Используется `BiosHandler`, `ShipCore` и другие компоненты.
+
+## Несоответствия и риски
+- [Факт][Med] Нет обработки ошибок при записи `.qiki_bot.id`.
+- [Факт][Low] При `minimal` режиме функции возвращают `None`/пустые списки без логирования.
+- [Гипотеза][Low] Отсутствует потокобезопасность при работе с колбэками.
+
+## Мини-патчи (safe-fix)
+- [Патч] Добавить логирование при работе в `minimal` режиме.
+- [Патч] Оборачивать запись файлов в `try/except`.
+
+## Рефактор-скетч
+```python
+class BotCore:
+    BOT_ID_FILE = ".qiki_bot.id"
+    CONFIG_FILE = "bot_config.json"
+
+    def __init__(self, base_path: str):
+        self.base_path = base_path
+        self._config = {}
+        self._sensor_callbacks = []
+        self._load_config()
+        self._initialize_bot_id()
+```
+
+## Примеры использования
+```python
+# 1. Создание экземпляра
+from services.q_core_agent.core.bot_core import BotCore
+bot = BotCore('/path/to/q_core_agent')
+
+# 2. Получение идентификатора
+print(bot.get_id())
+
+# 3. Регистрация колбэка сенсора
+from generated.sensor_raw_in_pb2 import SensorReading
+bot.register_sensor_callback(lambda s: print(s.sensor_id))
+bot._process_incoming_sensor_data(SensorReading(sensor_id='imu', value=1))
+
+# 4. Отправка команды актуатору
+from generated.actuator_raw_out_pb2 import ActuatorCommand
+cmd = ActuatorCommand(actuator_id='motor_left', command='set_velocity_percent', value=50)
+bot.send_actuator_command(cmd)
+
+# 5. Получение последнего значения сенсора
+bot.get_latest_sensor_value('imu')
+```
+
+## Тест-хуки/чек-лист
+- Проверить генерацию нового ID при отсутствии файла.
+- Убедиться, что неверный `actuator_id` вызывает `ValueError`.
+- Проверить работу колбэков и обновление снимка сенсоров.
+
+## Вывод
+1. `BotCore` управляет конфигурацией и коммуникацией с устройствами.
+2. Поддерживает режим `minimal` для тестов.
+3. Риск средней степени: отсутствие обработки ошибок записи файлов.
+4. Рекомендуется добавить логирование и защиту от гонок.
+5. Набор колбэков расширяет возможности интеграции.
+6. История сенсоров пока упрощена, нуждается в реализации.
+7. Код хорошо структурирован и документирован.
+8. Тесты должны покрывать генерацию ID и взаимодействие с актуаторами.
+9. Возможна интеграция с внешними сервисами через gRPC.
+10. Архитектура пригодна для дальнейшего развития.
+
+СПИСОК ФАЙЛОВ
+56. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/__init__.py
+57. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/agent_logger.py
+58. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/bios_handler.py
+59. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/bot_core.py
+60. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/mission_control_demo.py

--- a/QIKI_DTMP/services/q_core_agent/core/mission_control_demo.analysis.md
+++ b/QIKI_DTMP/services/q_core_agent/core/mission_control_demo.analysis.md
@@ -1,0 +1,95 @@
+СПИСОК ФАЙЛОВ
+56. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/__init__.py
+57. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/agent_logger.py
+58. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/bios_handler.py
+59. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/bot_core.py
+60. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/mission_control_demo.py
+
+## Вход и цель
+- [Факт] Анализ скрипта `mission_control_demo.py`.
+- [Цель] Понять демонстрацию интерфейса и предложить улучшения.
+
+## Сбор контекста
+- [Факт] Импортирует `ShipCore`, `ShipActuatorController`, `ThrusterAxis`, `PropulsionMode`, `ShipLogicController`.
+- [Факт] Предоставляет классы `MissionControlDemo` и функцию `main`.
+- [Гипотеза] Сценарий используется для CLI-демонстрации возможностей системы.
+
+## Локализация артефакта
+- [Факт] Путь: `services/q_core_agent/core/mission_control_demo.py`.
+- [Факт] Запускается как скрипт (`if __name__ == '__main__':`).
+
+## Фактический разбор
+- [Факт] Конструктор инициализирует `ShipCore`, контроллеры и время миссии.
+- [Факт] `render_interface` выводит телеметрию и журнал.
+- [Факт] `execute_demo_command` обрабатывает команды thrust/rcs/sensor/power/status.
+- [Факт] `interactive_demo` предоставляет цикл ввода команд.
+- [Факт] `main` предлагает выбор сценария или интерфейса.
+- [Гипотеза] Функции требуют реальных данных от `ShipCore`.
+
+## Роль в системе и связи
+- [Факт] Служит демонстрационным CLI для космического аппарата.
+- [Гипотеза] Может использоваться как пример интеграции с `ShipCore`.
+
+## Несоответствия и риски
+- [Факт][Low] Нет обработки отсутствия `ShipCore` конфигурации.
+- [Гипотеза][Med] Отсутствует ограничение на размер логов и ввод пользователя.
+
+## Мини-патчи (safe-fix)
+- [Патч] Добавить проверку конфигов перед запуском демо.
+- [Патч] Ограничить длину вводимой команды.
+
+## Рефактор-скетч
+```python
+class MissionControlDemo:
+    def __init__(self):
+        base = os.path.join(os.path.dirname(__file__), "..")
+        self.ship_core = ShipCore(base_path=base)
+        self.actuator_controller = ShipActuatorController(self.ship_core)
+        self.logic_controller = ShipLogicController(self.ship_core, self.actuator_controller)
+        self.mission_time_start = time.time()
+```
+
+## Примеры использования
+```bash
+# 1. Запуск демо
+python services/q_core_agent/core/mission_control_demo.py
+```
+```python
+# 2. Импорт и отрисовка интерфейса
+from services.q_core_agent.core.mission_control_demo import MissionControlDemo
+demo = MissionControlDemo()
+demo.render_interface()
+
+# 3. Выполнение команды thrust
+demo.execute_demo_command("thrust 10")
+
+# 4. Получение времени миссии
+print(demo.get_mission_time())
+
+# 5. Интерактивный режим (может быть прерван Ctrl+C)
+# demo.interactive_demo()
+```
+
+## Тест-хуки/чек-лист
+- Проверить корректность обработки команд `thrust`, `rcs`, `sensor`, `power`, `status`.
+- Убедиться, что интерфейс обновляется без исключений.
+- Проверить работу `interactive_demo` при ошибочном вводе.
+
+## Вывод
+1. Скрипт демонстрирует интерфейс Mission Control.
+2. Основной функционал завязан на `ShipCore` и контроллерах.
+3. Риски умеренные: возможны ошибки из-за внешних конфигов и неконтролируемого ввода.
+4. Добавление проверок и лимитов повысит устойчивость.
+5. Код нацелен на демонстрацию и содержит много вывода.
+6. Тесты должны эмулировать основные команды и сценарии.
+7. Расширение возможно через графический интерфейс.
+8. Структура скрипта линейная и легко читается.
+9. Логи и телеметрия отображаются в псевдографике.
+10. Скрипт полезен как пример использования API корабля.
+
+СПИСОК ФАЙЛОВ
+56. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/__init__.py
+57. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/agent_logger.py
+58. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/bios_handler.py
+59. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/bot_core.py
+60. [ ] /home/sonra44/QIKI_DTMP/services/q_core_agent/core/mission_control_demo.py


### PR DESCRIPTION
## Summary
- Добавлены Markdown-отчёты по пяти модулям: `__init__`, `agent_logger`, `bios_handler`, `bot_core`, `mission_control_demo`
- Описаны назначение, риски, примеры использования и рекомендации

## Testing
- `pytest` *(падает: ModuleNotFoundError: No module named 'google'; ModuleNotFoundError: No module named 'psutil'; ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68a263fce314833185a3f16203330498

## Summary by Sourcery

Documentation:
- Add Markdown analysis reports for five q_core_agent/core modules detailing their purpose, risks, usage examples, and recommendations