### PR TITLE
Добавлены обзоры protobuf модулей

### DIFF
--- a/analysis_generated/actuator_raw_out_pb2.md
+++ b/analysis_generated/actuator_raw_out_pb2.md
@@ -1,0 +1,91 @@
+СПИСОК ФАЙЛОВ
+- /home/sonra44/QIKI_DTMP/generated/actuator_raw_out_pb2.py
+- /home/sonra44/QIKI_DTMP/generated/bios_status_pb2_grpc.py
+- /home/sonra44/QIKI_DTMP/generated/bios_status_pb2.py
+- /home/sonra44/QIKI_DTMP/generated/common_types_pb2_grpc.py
+- /home/sonra44/QIKI_DTMP/generated/common_types_pb2.py
+СПИСОК ФАЙЛОВ
+
+# actuator_raw_out_pb2.py — анализ
+
+## Вход и цель
+- [Факт] Анализ файла `actuator_raw_out_pb2.py`, содержащего protobuf-описание команды для актуаторов.
+- [Гипотеза] Итог — обзор структуры сообщений и рисков.
+
+## Сбор контекста
+- [Факт] Файл сгенерирован из `actuator_raw_out.proto` и зависит от `common_types.proto`.
+- [Гипотеза] Используется при отправке команд к исполнительным устройствам.
+
+## Локализация артефакта
+- [Факт] Путь: `/home/sonra44/QIKI_DTMP/generated/actuator_raw_out_pb2.py`.
+- [Факт] Работает с `protobuf` версии 6.31.1.
+
+## Фактический разбор
+- [Факт] Импортируются `common_types_pb2` и `google.protobuf.timestamp_pb2`.
+- [Факт] Основное сообщение `ActuatorCommand` содержит поля идентификаторов, значения команд и перечисление `CommandType`.
+- [Факт] Значения команды расположены в `oneof command_value` (float/int/bool/vector).
+- [Гипотеза] Отсутствует явная валидация диапазонов.
+
+## Роль в системе и связи
+- [Факт] Сообщение служит контрактом между подсистемой управления и актуаторами.
+- [Гипотеза] Вызывается сервисами gRPC, генерирующими команды.
+
+## Несоответствия и риски
+- [Гипотеза] Незаполненное поле `unit` может привести к неверной интерпретации (Med).
+- [Гипотеза] Отсутствие проверки `retry_count` может вызвать переполнения (Low).
+
+## Мини-патчи (safe-fix)
+- [Патч] Установить значение `unit` по умолчанию на стороне сервиса.
+- [Патч] Добавить проверку максимального `retry_count`.
+
+## Рефактор-скетч
+```python
+from qiki.common import UUID, Vector3, Unit
+from google.protobuf.timestamp_pb2 import Timestamp
+from qiki.actuators import actuator_raw_out_pb2 as ar
+
+cmd = ar.ActuatorCommand(
+    command_id=UUID(value="0"*32),
+    actuator_id=UUID(value="1"*32),
+    timestamp=Timestamp(),
+    float_value=1.0,
+    unit=Unit.UNIT_UNSPECIFIED,
+    command_type=ar.ActuatorCommand.CommandType.SET_VELOCITY,
+)
+```
+
+## Примеры использования
+1. ```python
+from qiki.actuators import actuator_raw_out_pb2 as ar
+cmd = ar.ActuatorCommand(float_value=3.14)
+```
+2. ```python
+cmd = ar.ActuatorCommand(int_value=5)
+```
+3. ```python
+b = cmd.SerializeToString(); cmd2 = ar.ActuatorCommand.FromString(b)
+```
+4. ```python
+cmd.vector_value.x = 1.0
+```
+5. ```python
+cmd.command_type = ar.ActuatorCommand.CommandType.ENABLE
+```
+
+## Тест-хуки/чек-лист
+- [Факт] Проверить сериализацию/десериализацию `ActuatorCommand`.
+- [Гипотеза] Валидация поля `unit` в бизнес-логике.
+
+## Вывод
+1. [Факт] Файл корректно описывает структуру команды актуатора.
+2. [Гипотеза] Следует уточнить значения по умолчанию.
+3. [Патч] Ограничить `retry_count` и заполнять `unit`.
+4. Остальные действия могут быть отложены.
+
+СПИСОК ФАЙЛОВ
+- /home/sonra44/QIKI_DTMP/generated/actuator_raw_out_pb2.py
+- /home/sonra44/QIKI_DTMP/generated/bios_status_pb2_grpc.py
+- /home/sonra44/QIKI_DTMP/generated/bios_status_pb2.py
+- /home/sonra44/QIKI_DTMP/generated/common_types_pb2_grpc.py
+- /home/sonra44/QIKI_DTMP/generated/common_types_pb2.py
+СПИСОК ФАЙЛОВ

--- a/analysis_generated/bios_status_pb2.md
+++ b/analysis_generated/bios_status_pb2.md
@@ -1,0 +1,88 @@
+СПИСОК ФАЙЛОВ
+- /home/sonra44/QIKI_DTMP/generated/actuator_raw_out_pb2.py
+- /home/sonra44/QIKI_DTMP/generated/bios_status_pb2_grpc.py
+- /home/sonra44/QIKI_DTMP/generated/bios_status_pb2.py
+- /home/sonra44/QIKI_DTMP/generated/common_types_pb2_grpc.py
+- /home/sonra44/QIKI_DTMP/generated/common_types_pb2.py
+СПИСОК ФАЙЛОВ
+
+# bios_status_pb2.py — анализ
+
+## Вход и цель
+- [Факт] Описание статуса BIOS и устройств.
+- [Гипотеза] Итог — обзор структур для мониторинга.
+
+## Сбор контекста
+- [Факт] Использует `common_types_pb2` и `timestamp_pb2`.
+- [Гипотеза] Служит для отчетов о состоянии системы.
+
+## Локализация артефакта
+- [Факт] Путь: `/home/sonra44/QIKI_DTMP/generated/bios_status_pb2.py`.
+- [Факт] Версия protobuf 6.31.1.
+
+## Фактический разбор
+- [Факт] Сообщение `DeviceStatus` с полями `device_id`, `status`, `device_type`, `status_code` и вложенными enum.
+- [Факт] Сообщение `BiosStatusReport` агрегирует список `DeviceStatus` и общие метрики.
+- [Гипотеза] `health_score` требует нормировки 0..1.
+
+## Роль в системе и связи
+- [Факт] Формирует единый отчет BIOS для диагностики.
+- [Гипотеза] Используется сервисами мониторинга и логирования.
+
+## Несоответствия и риски
+- [Гипотеза] Неявное значение `all_systems_go` может быть неверно интерпретировано (Med).
+- [Гипотеза] Отсутствие ограничений для `health_score` (Med).
+
+## Мини-патчи (safe-fix)
+- [Патч] Добавить проверку диапазона `health_score`.
+- [Патч] Документировать поведение `all_systems_go`.
+
+## Рефактор-скетч
+```python
+from qiki.bios import bios_status_pb2 as bs
+from qiki.common import UUID
+from google.protobuf.timestamp_pb2 import Timestamp
+
+status = bs.DeviceStatus(
+    device_id=UUID(value="deadbeef"),
+    device_name="sensor",
+    status=bs.DeviceStatus.Status.OK,
+    device_type=bs.DeviceStatus.DeviceType.SENSOR,
+)
+report = bs.BiosStatusReport(timestamp=Timestamp(), post_results=[status])
+```
+
+## Примеры использования
+1. ```python
+s = bs.DeviceStatus(status=bs.DeviceStatus.Status.ERROR)
+```
+2. ```python
+s.device_type = bs.DeviceStatus.DeviceType.ACTUATOR
+```
+3. ```python
+r = bs.BiosStatusReport(post_results=[s])
+```
+4. ```python
+for d in r.post_results:
+    print(d.device_name)
+```
+5. ```python
+r.all_systems_go = True
+```
+
+## Тест-хуки/чек-лист
+- [Факт] Проверить корректность перечислений `StatusCode`.
+- [Гипотеза] Тестировать нормировку `health_score`.
+
+## Вывод
+1. [Факт] Файл задает структурированный отчет BIOS.
+2. [Гипотеза] Требуются ограничения на числовые поля.
+3. [Патч] Ввести валидацию `health_score` и флага `all_systems_go`.
+
+СПИСОК ФАЙЛОВ
+- /home/sonra44/QIKI_DTMP/generated/actuator_raw_out_pb2.py
+- /home/sonra44/QIKI_DTMP/generated/bios_status_pb2_grpc.py
+- /home/sonra44/QIKI_DTMP/generated/bios_status_pb2.py
+- /home/sonra44/QIKI_DTMP/generated/common_types_pb2_grpc.py
+- /home/sonra44/QIKI_DTMP/generated/common_types_pb2.py
+СПИСОК ФАЙЛОВ

--- a/analysis_generated/bios_status_pb2_grpc.md
+++ b/analysis_generated/bios_status_pb2_grpc.md
@@ -1,0 +1,80 @@
+СПИСОК ФАЙЛОВ
+- /home/sonra44/QIKI_DTMP/generated/actuator_raw_out_pb2.py
+- /home/sonra44/QIKI_DTMP/generated/bios_status_pb2_grpc.py
+- /home/sonra44/QIKI_DTMP/generated/bios_status_pb2.py
+- /home/sonra44/QIKI_DTMP/generated/common_types_pb2_grpc.py
+- /home/sonra44/QIKI_DTMP/generated/common_types_pb2.py
+СПИСОК ФАЙЛОВ
+
+# bios_status_pb2_grpc.py — анализ
+
+## Вход и цель
+- [Факт] Файл содержит проверку совместимости версий gRPC.
+- [Гипотеза] Итог — чек-лист по использованию.
+
+## Сбор контекста
+- [Факт] Импортируется только модуль `grpc` и `warnings`.
+- [Гипотеза] Сервисные классы отсутствуют, значит протокол не определяет RPC.
+
+## Локализация артефакта
+- [Факт] Путь: `/home/sonra44/QIKI_DTMP/generated/bios_status_pb2_grpc.py`.
+- [Факт] Требует `grpcio>=1.74.0`.
+
+## Фактический разбор
+- [Факт] Константы `GRPC_GENERATED_VERSION` и `GRPC_VERSION` сравниваются.
+- [Факт] При несовместимости вызывается `RuntimeError` с инструкциями по обновлению.
+- [Гипотеза] Предназначен для раннего выявления несовместимых версий.
+
+## Роль в системе и связи
+- [Факт] Обеспечивает корректность окружения перед использованием protobuf-сервисов.
+- [Гипотеза] Вызывается автоматически при импорте модуля.
+
+## Несоответствия и риски
+- [Гипотеза] Жёсткая проверка версии может мешать при патч-версиях (Low).
+
+## Мини-патчи (safe-fix)
+- [Патч] Добавить логирование версии вместо исключения в режиме отладки.
+
+## Рефактор-скетч
+```python
+import grpc
+from qiki.bios import bios_status_pb2_grpc as bs
+
+print(bs.GRPC_GENERATED_VERSION)
+```
+
+## Примеры использования
+1. ```python
+import bios_status_pb2_grpc as bs
+```
+2. ```python
+print(bs.GRPC_VERSION)
+```
+3. ```python
+assert bs.GRPC_VERSION >= bs.GRPC_GENERATED_VERSION
+```
+4. ```python
+try:
+    import bios_status_pb2_grpc as bs
+except RuntimeError as e:
+    print(e)
+```
+5. ```bash
+python -c "import bios_status_pb2_grpc"
+```
+
+## Тест-хуки/чек-лист
+- [Факт] Проверить импорт при разных версиях `grpc`.
+
+## Вывод
+1. [Факт] Модуль выполняет только проверку версии gRPC.
+2. [Гипотеза] Требуется гибкость при мелких обновлениях.
+3. [Патч] Добавить режим предупреждения.
+
+СПИСОК ФАЙЛОВ
+- /home/sonra44/QIKI_DTMP/generated/actuator_raw_out_pb2.py
+- /home/sonra44/QIKI_DTMP/generated/bios_status_pb2_grpc.py
+- /home/sonra44/QIKI_DTMP/generated/bios_status_pb2.py
+- /home/sonra44/QIKI_DTMP/generated/common_types_pb2_grpc.py
+- /home/sonra44/QIKI_DTMP/generated/common_types_pb2.py
+СПИСОК ФАЙЛОВ

--- a/analysis_generated/common_types_pb2.md
+++ b/analysis_generated/common_types_pb2.md
@@ -1,0 +1,79 @@
+СПИСОК ФАЙЛОВ
+- /home/sonra44/QIKI_DTMP/generated/actuator_raw_out_pb2.py
+- /home/sonra44/QIKI_DTMP/generated/bios_status_pb2_grpc.py
+- /home/sonra44/QIKI_DTMP/generated/bios_status_pb2.py
+- /home/sonra44/QIKI_DTMP/generated/common_types_pb2_grpc.py
+- /home/sonra44/QIKI_DTMP/generated/common_types_pb2.py
+СПИСОК ФАЙЛОВ
+
+# common_types_pb2.py — анализ
+
+## Вход и цель
+- [Факт] Содержит общие типы: UUID, Vector3, перечисления для сенсоров/актуаторов/единиц измерения.
+- [Гипотеза] Итог — обзор базовых структур.
+
+## Сбор контекста
+- [Факт] Зависит от `timestamp_pb2`.
+- [Гипотеза] Используется большинством модулей системы.
+
+## Локализация артефакта
+- [Факт] Путь: `/home/sonra44/QIKI_DTMP/generated/common_types_pb2.py`.
+- [Факт] Protobuf 6.31.1.
+
+## Фактический разбор
+- [Факт] Определены сообщения `UUID`, `Vector3`.
+- [Факт] Enum `SensorType`, `ActuatorType`, `Unit` описывают базовые константы.
+- [Гипотеза] Нет алиасов для пользовательских единиц.
+
+## Роль в системе и связи
+- [Факт] Является фундаментом всех других сообщений.
+- [Гипотеза] Несовместимость здесь затронет весь проект.
+
+## Несоответствия и риски
+- [Гипотеза] Отсутствие проверки формата строки UUID (Med).
+- [Гипотеза] Неполный список единиц измерения (Low).
+
+## Мини-патчи (safe-fix)
+- [Патч] Добавить валидацию UUID на уровне бизнес-логики.
+- [Патч] Расширить enum `Unit` при необходимости.
+
+## Рефактор-скетч
+```python
+from qiki.common import common_types_pb2 as ct
+u = ct.UUID(value="1234")
+v = ct.Vector3(x=1.0, y=2.0, z=3.0)
+```
+
+## Примеры использования
+1. ```python
+uid = ct.UUID(value="abcd")
+```
+2. ```python
+vec = ct.Vector3(x=0.0, y=1.0, z=2.0)
+```
+3. ```python
+type = ct.SensorType.LIDAR
+```
+4. ```python
+atype = ct.ActuatorType.GRIPPER
+```
+5. ```python
+unit = ct.Unit.METERS
+```
+
+## Тест-хуки/чек-лист
+- [Факт] Валидация допустимости строк UUID.
+- [Гипотеза] Тест на сериализацию `Vector3`.
+
+## Вывод
+1. [Факт] Файл предоставляет базовые структуры для всего проекта.
+2. [Гипотеза] Стоит расширить проверки корректности.
+3. [Патч] Ввести валидацию UUID и дополнить `Unit`.
+
+СПИСОК ФАЙЛОВ
+- /home/sonra44/QIKI_DTMP/generated/actuator_raw_out_pb2.py
+- /home/sonra44/QIKI_DTMP/generated/bios_status_pb2_grpc.py
+- /home/sonra44/QIKI_DTMP/generated/bios_status_pb2.py
+- /home/sonra44/QIKI_DTMP/generated/common_types_pb2_grpc.py
+- /home/sonra44/QIKI_DTMP/generated/common_types_pb2.py
+СПИСОК ФАЙЛОВ

--- a/analysis_generated/common_types_pb2_grpc.md
+++ b/analysis_generated/common_types_pb2_grpc.md
@@ -1,0 +1,80 @@
+СПИСОК ФАЙЛОВ
+- /home/sonra44/QIKI_DTMP/generated/actuator_raw_out_pb2.py
+- /home/sonra44/QIKI_DTMP/generated/bios_status_pb2_grpc.py
+- /home/sonra44/QIKI_DTMP/generated/bios_status_pb2.py
+- /home/sonra44/QIKI_DTMP/generated/common_types_pb2_grpc.py
+- /home/sonra44/QIKI_DTMP/generated/common_types_pb2.py
+СПИСОК ФАЙЛОВ
+
+# common_types_pb2_grpc.py — анализ
+
+## Вход и цель
+- [Факт] Модуль для проверки версии gRPC в общих типах.
+- [Гипотеза] Итог — рекомендации по окружению.
+
+## Сбор контекста
+- [Факт] Импортируется `grpc` и `warnings`; сервисы не объявлены.
+- [Гипотеза] Обеспечивает совместимость для других модулей.
+
+## Локализация артефакта
+- [Факт] Путь: `/home/sonra44/QIKI_DTMP/generated/common_types_pb2_grpc.py`.
+- [Факт] Требует `grpcio>=1.74.0`.
+
+## Фактический разбор
+- [Факт] Сравнивает версии и бросает `RuntimeError` при несовпадении.
+- [Гипотеза] Используется автоматически при импорте.
+
+## Роль в системе и связи
+- [Факт] Гарантирует корректное окружение для общих типов.
+- [Гипотеза] Зависимостями являются все protobuf-модули проекта.
+
+## Несоответствия и риски
+- [Гипотеза] Жёсткая зависимость от точной версии (Low).
+
+## Мини-патчи (safe-fix)
+- [Патч] Разрешить диапазон версий при применении `packaging.version`.
+
+## Рефактор-скетч
+```python
+import grpc
+from qiki.common import common_types_pb2_grpc as ct
+
+print(ct.GRPC_GENERATED_VERSION)
+```
+
+## Примеры использования
+1. ```python
+import common_types_pb2_grpc as ct
+```
+2. ```python
+print(ct.GRPC_VERSION)
+```
+3. ```python
+if ct.GRPC_VERSION < ct.GRPC_GENERATED_VERSION:
+    raise SystemExit("grpc too old")
+```
+4. ```python
+try:
+    import common_types_pb2_grpc
+except RuntimeError:
+    pass
+```
+5. ```bash
+python -c "import common_types_pb2_grpc"
+```
+
+## Тест-хуки/чек-лист
+- [Факт] Импортировать модуль под различными версиями gRPC.
+
+## Вывод
+1. [Факт] Модуль выполняет проверку версий.
+2. [Гипотеза] Требуется более гибкая политика совместимости.
+3. [Патч] Ввести проверку диапазона версий.
+
+СПИСОК ФАЙЛОВ
+- /home/sonra44/QIKI_DTMP/generated/actuator_raw_out_pb2.py
+- /home/sonra44/QIKI_DTMP/generated/bios_status_pb2_grpc.py
+- /home/sonra44/QIKI_DTMP/generated/bios_status_pb2.py
+- /home/sonra44/QIKI_DTMP/generated/common_types_pb2_grpc.py
+- /home/sonra44/QIKI_DTMP/generated/common_types_pb2.py
+СПИСОК ФАЙЛОВ


### PR DESCRIPTION
## Изменения
- добавлены Markdown-обзоры для protobuf-файлов actuator_raw_out_pb2, bios_status_pb2, bios_status_pb2_grpc, common_types_pb2, common_types_pb2_grpc

## Проверки
- `python -m py_compile QIKI_DTMP/QIKI_DTMP/generated/actuator_raw_out_pb2.py QIKI_DTMP/QIKI_DTMP/generated/bios_status_pb2_grpc.py QIKI_DTMP/QIKI_DTMP/generated/bios_status_pb2.py QIKI_DTMP/QIKI_DTMP/generated/common_types_pb2_grpc.py QIKI_DTMP/QIKI_DTMP/generated/common_types_pb2.py`


------
https://chatgpt.com/codex/tasks/task_e_68a263bb2fdc8331be39614e71924ca1

## Summary by Sourcery

Add Markdown overview documentation for generated protobuf modules to provide structural analyses and usage guidelines.

Documentation:
- Add Markdown review for actuator_raw_out_pb2 module
- Add Markdown review for bios_status_pb2 module
- Add Markdown review for bios_status_pb2_grpc module
- Add Markdown review for common_types_pb2 module
- Add Markdown review for common_types_pb2_grpc module