### PR TITLE
feat: добавить Pydantic‑модели конфигураций

### DIFF
--- a/config_models.py
+++ b/config_models.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Type, TypeVar
+import json
+import yaml
+
+from pydantic import BaseModel, PositiveFloat, conint, IPvAnyAddress
+
+
+class ShipConfig(BaseModel):
+    """Конфигурация корабля."""
+
+    name: str
+    max_speed: PositiveFloat
+    capacity: conint(ge=0)
+
+
+class NetworkConfig(BaseModel):
+    """Параметры сети."""
+
+    host: str
+    port: conint(gt=0, lt=65536)
+
+
+class SecurityConfig(BaseModel):
+    """Настройки безопасности."""
+
+    use_tls: bool = False
+    allowed_ips: List[IPvAnyAddress] = []
+
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def load_config(path: Path, model: Type[T]) -> T:
+    """Загрузить конфигурацию из JSON или YAML с валидацией."""
+    with path.open() as f:
+        if path.suffix.lower() in {".yaml", ".yml"}:
+            data = yaml.safe_load(f)
+        else:
+            data = json.load(f)
+    return model.model_validate(data) if hasattr(model, 'model_validate') else model.parse_obj(data)

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -1,0 +1,58 @@
+import json
+from pathlib import Path
+
+import sys
+import pytest
+from pydantic import ValidationError
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from config_models import (
+    ShipConfig,
+    NetworkConfig,
+    SecurityConfig,
+    load_config,
+)
+
+
+def write_file(path: Path, data):
+    if path.suffix in {'.yaml', '.yml'}:
+        import yaml
+        with path.open('w') as f:
+            yaml.safe_dump(data, f)
+    else:
+        with path.open('w') as f:
+            json.dump(data, f)
+
+
+def test_ship_config_valid(tmp_path: Path):
+    data = {"name": "Voyager", "max_speed": 1.5, "capacity": 10}
+    file = tmp_path / 'ship.json'
+    write_file(file, data)
+    cfg = load_config(file, ShipConfig)
+    assert cfg.max_speed == 1.5
+    assert cfg.capacity == 10
+
+
+def test_ship_config_negative_speed(tmp_path: Path):
+    data = {"name": "Voyager", "max_speed": -1.0, "capacity": 10}
+    file = tmp_path / 'ship.json'
+    write_file(file, data)
+    with pytest.raises(ValidationError):
+        load_config(file, ShipConfig)
+
+
+def test_network_config_invalid_port(tmp_path: Path):
+    data = {"host": "localhost", "port": 0}
+    file = tmp_path / 'net.yaml'
+    write_file(file, data)
+    with pytest.raises(ValidationError):
+        load_config(file, NetworkConfig)
+
+
+def test_security_config_invalid_ip(tmp_path: Path):
+    data = {"use_tls": True, "allowed_ips": ["999.999.999.999"]}
+    file = tmp_path / 'sec.json'
+    write_file(file, data)
+    with pytest.raises(ValidationError):
+        load_config(file, SecurityConfig)


### PR DESCRIPTION
## Summary
- добавить модели ShipConfig, NetworkConfig и SecurityConfig на Pydantic
- реализовать загрузку JSON/YAML через валидируемые модели
- покрыть конфигурации тестами на корректность и ошибки

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a27e50895c8331b3d6521b0917ee11

## Summary by Sourcery

Add Pydantic-based configuration models and a loader with accompanying tests to validate JSON and YAML config files

New Features:
- Introduce Pydantic models ShipConfig, NetworkConfig, and SecurityConfig for structured configuration
- Implement load_config function to parse and validate JSON or YAML configuration files

Tests:
- Add tests to verify valid configurations and to raise ValidationError on invalid config values